### PR TITLE
Adding night-timelapse feature for smoother transition and notifications to other players.

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -4,6 +4,8 @@ minPlayers: 2
 # the ration of players which have to sleep
 # set it to 1 or 100% to use the plugin and normal sleeping behavior but with the benefit of ignored 
 sleepPercentage: 0.5
+# Speed of time for a smoother transition to the morning. Set to 0 to disable this feature. 
+nightSpeed: 300  
 # use {player} for the sleeping players name
 # use {sleeping} for the count of the sleeping players
 # use {online} for the online playercount
@@ -14,3 +16,5 @@ msg:
     sleep: "{player} is now sleeping. {sleeping}/{online} ({percentage}%)"
     leave: "{player} is no longer sleeping. {sleeping}/{online} ({percentage}%) {more} more required!"
     wake: "Wakey wakey, rise and shine... Good morning everyone!"
+    notify: "{sleeping} players have gone to bed. Skipping the night!"
+    notifyOnSingle: "{player} has gone to bed. Skipping the night!"

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,8 +1,8 @@
 name: BetterBeds
 main: de.themoep.BetterBeds.BetterBeds
-version: 0.4.1
+version: 0.5.0
 description: Better bed and sleeping handling for large servers
-authors: [Phoenix616]
+authors: [Phoenix616, NeoTiger]
 website: http://dev.bukkit.org/bukkit-plugins/betterbeds/
 commands:
    betterbedsreload:


### PR DESCRIPTION
I liked the mod, but I always felt the transition too dawn was too instantaneous and also lacking a notification for other players that didn't go to bed. So I decided to add these things in myself.

A new configuration "nightSpeed" now allows to set a timelapse factor for the night. A Value of 300 would make the night pass by within two seconds. If any player leaves the bed during timelapse, it will be interrupted. If set to 0, it will behave like previously.

Also all other players in the world will be informed about skipping the night. If only one player was enough to trigger it, his name will also be communicated.

I also took the liberty of removing the logging of the configuration message during onEnable().

If you like to pull this, consider it with care, I'm rather new to Bukkit plugin development.
