### PR TITLE
Add WhosAFK integration

### DIFF
--- a/src/main/java/de/themoep/BetterBeds/BetterBeds.java
+++ b/src/main/java/de/themoep/BetterBeds/BetterBeds.java
@@ -322,10 +322,14 @@ public class BetterBeds extends JavaPlugin implements Listener {
 	 */
 	private boolean isPlayerAFK(Player p) {
 		// Player is AFK according to WhosAFK
-		// TODO: check for exceptions/ensure WhosAFK is loaded
-		WhosAFK whosafk = JavaPlugin.getPlugin(WhosAFK.class);
-		if (whosafk.isEnabled() && whosafk.playerIsAFK(p))
-			return true;
+		try {
+			// Test for ClassNotFoundException
+			Class.forName("whosafk.WhosAFK");
+
+			WhosAFK whosafk = JavaPlugin.getPlugin(WhosAFK.class);
+			if (whosafk.isEnabled() && whosafk.playerIsAFK(p))
+				return true;
+		} catch (ClassNotFoundException e) {}
 
 		// Default to not AFK
 		return false;

--- a/src/main/java/de/themoep/BetterBeds/BetterBeds.java
+++ b/src/main/java/de/themoep/BetterBeds/BetterBeds.java
@@ -16,6 +16,8 @@ import org.bukkit.event.player.PlayerBedLeaveEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
 
 public class BetterBeds extends JavaPlugin implements Listener {
 	
@@ -306,9 +308,29 @@ public class BetterBeds extends JavaPlugin implements Listener {
 	private int countQualifyingPlayers(World world) {
 		int calculatedPlayers = 0;
 		for(Player p : getServer().getOnlinePlayers())
-			if(world.equals(p.getWorld()) && !p.hasPermission("betterbeds.ignore") && p.hasPermission("betterbeds.sleep"))
+			if(world.equals(p.getWorld()) && !p.hasPermission("betterbeds.ignore") && p.hasPermission("betterbeds.sleep") && !isPlayerAFK(p))
 				calculatedPlayers ++;
 		return calculatedPlayers;
+	}
+
+	/**
+	 * Check if a player is AFK
+	 * Currently this only works with the WhosAFK plugin
+	 * TODO: Add support for checking with more methods
+	 * TODO: Add a config option to decide whether AFK players should be counted
+	 * @param Player
+	 * @return boolean - True if Player is currently AFK
+	 */
+	private boolean isPlayerAFK(Player p) {
+		Scoreboard scoreboard = getServer().getScoreboardManager().getMainScoreboard();
+
+		// Players are added to the afkers team by WhosAFK
+		Team afkers = scoreboard.getTeam("afkers");
+		if (afkers != null)
+			return afkers.hasEntry(p.getName());
+
+		// Default to not AFK
+		return false;
 	}
 
 	/**

--- a/src/main/java/de/themoep/BetterBeds/BetterBeds.java
+++ b/src/main/java/de/themoep/BetterBeds/BetterBeds.java
@@ -16,8 +16,7 @@ import org.bukkit.event.player.PlayerBedLeaveEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
+import whosafk.WhosAFK;
 
 public class BetterBeds extends JavaPlugin implements Listener {
 	
@@ -322,12 +321,11 @@ public class BetterBeds extends JavaPlugin implements Listener {
 	 * @return boolean - True if Player is currently AFK
 	 */
 	private boolean isPlayerAFK(Player p) {
-		Scoreboard scoreboard = getServer().getScoreboardManager().getMainScoreboard();
-
-		// Players are added to the afkers team by WhosAFK
-		Team afkers = scoreboard.getTeam("afkers");
-		if (afkers != null)
-			return afkers.hasEntry(p.getName());
+		// Player is AFK according to WhosAFK
+		// TODO: check for exceptions/ensure WhosAFK is loaded
+		WhosAFK whosafk = JavaPlugin.getPlugin(WhosAFK.class);
+		if (whosafk.isEnabled() && whosafk.playerIsAFK(p))
+			return true;
 
 		// Default to not AFK
 		return false;

--- a/src/main/java/de/themoep/BetterBeds/BetterBeds.java
+++ b/src/main/java/de/themoep/BetterBeds/BetterBeds.java
@@ -145,7 +145,7 @@ public class BetterBeds extends JavaPlugin implements Listener {
             if(world.equals(p.getWorld())) {
                 if (!p.isSleeping() && p.hasPermission("betterbeds.ghost") && !p.hasPermission("betterbeds.ghost.buster"))
                     return false;
-                if (p.hasPermission("betterbeds.sleep") && !p.hasPermission("betterbeds.ignore"))
+                if (p.hasPermission("betterbeds.sleep") && !p.hasPermission("betterbeds.ignore") && !isPlayerAFK(p))
                     calculatedPlayers++;
             }
 		}		


### PR DESCRIPTION
I have taken your feedback and done a bit of research into dynamic class loading. Hopefully you like this version better :smile: 

I have left the commit history in so that you can see my thought process (maybe that was a bad idea!), so I'd recommend doing a squashed merge when/if you decide to merge. If you do a squashed merge, please use this for the commit message body:

```
Adds a method "isPlayerAFK(Player)" that checks if the given player is
currently AFK.

For now this method checks with the WhosAFK plugin, but it has been
written to allow checking with multiple plugins in the future.
```

This uses Java's dynamic class loading to find the `WhosAFK` class so that it's jar is not needed at compile time. This also allows us to check the `ClassNotFoundException` to know if the jar is present or not.

We then ask spigot for the instance of `WhosAFK` being used and check if it is enabled and whether the player is AFK. If so, we return `true`.

If the player is not AFK the method continues so that other AFK-plugins could be checked, before finally returning `false`.
